### PR TITLE
Feeds URLs and folders configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ It stores new items in the mail folders using IMAP APPEND command (java.mail fra
 ### Configuration
 By default configuration dir is `$HOME/.config/feeds2imap.clj`.
 
-Only file than required to run code is imap.clj. Take a look at imap.clj.example file for details.
+The only file required to run the code is *imap.clj*. Take a look at *imap.clj.example* for details.
+
+Feeds and folders can be added using the `add` command (see below), or you can write them directly in the *urls.clj* file (inside the configuration directory). The format of this file is as follows:
+
+```clojure
+{"folder1" ["url1" "url2" ...]
+ "folder2" [...]
+ ...}
+```
 
 ### Usage
 You can use `lein run` to run programm or you can generate jar with `lein uberjar` and run programm with `java -jar <path-to-jar>`.


### PR DESCRIPTION
I've added some words in README.md on how to configure feeds URLs and folders by directly editing the _urls.clj_ configuration file. It can be useful if someone wants to import his feeds by directly writing out an EDN data structure into the configuration file with a custom program.
