### PR TITLE
Add opml2clj command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ The format of this file is as follows:
 ### Usage
 You can use `lein run` to run programm or you can generate jar with `lein uberjar` and run programm with `java -jar <path-to-jar>`.
 
-* `LAUNCH-COMMAND` - pull new items.
+ * `LAUNCH-COMMAND` - pull new items.
 * `LAUNCH-COMMAND pull` - pull new items.
 * `LAUNCH-COMMAND auto` - pull new items every 1 hour in the loop.
 * `LAUNCH-COMMAND show` - show feeds list (url.clj file content).
 * `LAUNCH-COMMAND add folder-name feed-url` - add url to feeds file to the folder folder-name.
+* `LAUNCH-COMMAND opml2clj filename.xml [path/to/urls.clj]` - convert OPML file to `urls.clj` format
 
 where `LAUNCH-COMMAND = lein run / lein trampoline run / java -jar jarfile.jar`.
 

--- a/src/feeds2imap/core.clj
+++ b/src/feeds2imap/core.clj
@@ -5,9 +5,11 @@
             [feeds2imap.imap :as imap]
             [feeds2imap.folder :as folder]
             [feeds2imap.macro :refer :all]
+            [feeds2imap.opml :refer [convert-opml]]
             [clojure.tools.logging :refer [info error]]
             [clojure.pprint :refer [pprint]]
-            [clojure.core.typed :refer :all])
+            [clojure.core.typed :refer :all]
+            [clojure.java.io :refer [file writer]])
   (:import [java.net NoRouteToHostException UnknownHostException]
            [javax.mail MessagingException]
            [clojure.lang Keyword]))
@@ -58,7 +60,16 @@
           "show" (show)
           "pull" (pull))
     (shutdown-agents))
+  ([command arg]
+     (case command
+       "opml2clj" (->> (java.io.File. ^String arg)
+                       convert-opml
+                       pprint)))
   ([command arg1 arg2]
     (case command
-          "add" (do (add arg1 arg2) (show)))
+          "add" (do (add arg1 arg2) (show))
+          "opml2clj" (let [w (writer (file arg2))
+                           m (->> (java.io.File. ^String arg1)
+                                  convert-opml)]
+                       (pprint m w)))
     (shutdown-agents)))

--- a/src/feeds2imap/opml.clj
+++ b/src/feeds2imap/opml.clj
@@ -1,0 +1,55 @@
+(ns feeds2imap.opml
+  (:require [clojure.pprint :refer [pprint]]
+            clojure.xml))
+
+(defn opml-find-tag
+  [tag-keyword xml]
+  (when xml
+    (if (sequential? xml)
+      (->> xml
+           (map #(opml-find-tag tag-keyword %))
+           (filter identity)
+           first)
+      (if (= tag-keyword (:tag xml))
+        xml
+        (recur tag-keyword (:content xml))))))
+
+(defn opml-folder-keyword
+  [xml-el]
+  (->> (:title (:attrs xml-el))
+       (replace {\space \-})
+       (filter #(or (java.lang.Character/isLetterOrDigit ^java.lang.Character %)
+                    (#{\- \_ \. \? \! \# \$ \%} %)))
+       (apply str)
+       keyword))
+
+(defn opml-build-entry
+  "Returns a string with a feed URL or a map."
+  [xml-outline]
+  ;; nested folders not supported
+  (:xmlUrl (:attrs xml-outline)))
+
+(defn opml-build-map
+  "Returns a map of :foldernames to vectors of URLs.
+  Entries without a folder are assigned to :__global__."
+  [xml-outlines]
+  (let [update-m (fn [m xml-el]
+                   (if (not (:xmlUrl (:attrs xml-el)))
+                     ;; a folder
+                     (let [key   (opml-folder-keyword xml-el)
+                           inner (->> (:content xml-el)
+                                      (map opml-build-entry)
+                                      (filter identity)
+                                      vec)]
+                       (assoc m key inner))
+                     ;; an entry
+                     (update-in m [:__global__] conj (:xmlUrl xml-el))
+                     ))]
+    (reduce update-m {} xml-outlines)))
+
+(defn convert-opml [istream]
+  "Takes an input stream with OPML contents, returns a map for `urls.clj`."
+  (let [x (clojure.xml/parse istream)
+        b (opml-find-tag :body x)
+        m (opml-build-map (:content b))]
+    m))


### PR DESCRIPTION
Most users migrating to feeds2imap.clj have an OPML file with their subscriptions. Writing `urls.clj` manually is a tedious task.

This PR adds a new command (`opml2clj`) to feeds2imap to convert an OPML file to its `urls.clj` format. Tested with some Google Reader and Feedly OPMLs. Only one level of `<outline>`'s nesting is supported (i.e. only a flat list of folders).
